### PR TITLE
Add a runtime argument for native vs container R on the LPC

### DIFF
--- a/R/populate_targets_proj.R
+++ b/R/populate_targets_proj.R
@@ -5,11 +5,11 @@
 #' @description
 #' This function creates a minimal targets template in the current directory. This includes creating a `Pipelines.qmd` file containing boilerplate for running analyses, and a `Results.qmd` file which can be used to visualize the results. Parallelization of the pipeline is implemented using [targets::tar_make()] and `crew.cluster`, using pre-filled using parameters specific to the LPC system at Penn.
 #'
-#' The `runtime` argument selects the R installation the pipeline runs against, and is passed through to [use_crew_lsf()]. `"container"` runs the main `targets` process and every worker inside the LPC's RStudio Singularity image; `"native"` loads the LPC's R module instead and leaves the package library to `renv`.
+#' The `runtime` argument selects the R installation the pipeline runs against, and is passed through to [use_crew_lsf()]. `"native"`, the default, loads the LPC's R module and leaves the package library to `renv`; `"container"` instead runs the main `targets` process and every worker inside the LPC's RStudio Singularity image.
 #'
 #' @param title (character) base name for project files (eg. "{title}-Pipeline.qmd" and "{title}-Results.qmd")
 #' @param log_folder (character) directory for LSF logs
-#' @param runtime (character) R runtime the pipeline and its LSF workers use: `"container"` for the LPC RStudio Singularity image, or `"native"` for the module-provided R
+#' @param runtime (character) R runtime the pipeline and its LSF workers use: `"native"` (the default) for the module-provided R, or `"container"` for the LPC RStudio Singularity image
 #' @param overwrite (logical) overwrite existing template files
 #'
 #' @export
@@ -17,12 +17,12 @@
 #' @examples
 #' \dontrun{
 #' populate_targets_proj("test")
-#' populate_targets_proj("test", runtime = "native")
+#' populate_targets_proj("test", runtime = "container")
 #' }
 
 populate_targets_proj <- function(title,
                                   log_folder = "build_logs",
-                                  runtime = c("container", "native"),
+                                  runtime = c("native", "container"),
                                   overwrite = FALSE) {
   runtime <- rlang::arg_match(runtime)
 

--- a/R/populate_targets_proj.R
+++ b/R/populate_targets_proj.R
@@ -5,8 +5,11 @@
 #' @description
 #' This function creates a minimal targets template in the current directory. This includes creating a `Pipelines.qmd` file containing boilerplate for running analyses, and a `Results.qmd` file which can be used to visualize the results. Parallelization of the pipeline is implemented using [targets::tar_make()] and `crew.cluster`, using pre-filled using parameters specific to the LPC system at Penn.
 #'
+#' The `runtime` argument selects the R installation the pipeline runs against, and is passed through to [use_crew_lsf()]. `"container"` runs the main `targets` process and every worker inside the LPC's RStudio Singularity image; `"native"` loads the LPC's R module instead and leaves the package library to `renv`.
+#'
 #' @param title (character) base name for project files (eg. "{title}-Pipeline.qmd" and "{title}-Results.qmd")
 #' @param log_folder (character) directory for LSF logs
+#' @param runtime (character) R runtime the pipeline and its LSF workers use: `"container"` for the LPC RStudio Singularity image, or `"native"` for the module-provided R
 #' @param overwrite (logical) overwrite existing template files
 #'
 #' @export
@@ -14,11 +17,15 @@
 #' @examples
 #' \dontrun{
 #' populate_targets_proj("test")
+#' populate_targets_proj("test", runtime = "native")
 #' }
 
 populate_targets_proj <- function(title,
                                   log_folder = "build_logs",
+                                  runtime = c("container", "native"),
                                   overwrite = FALSE) {
+  runtime <- rlang::arg_match(runtime)
+
   # Create title
   if (missing(title)) {
     title <- basename(here::here())
@@ -35,11 +42,16 @@ populate_targets_proj <- function(title,
   fs::dir_create(log_folder)
   cli::cli_alert_success("Build log folder created at {.file {log_folder}}")
 
-  # Copy batch script for job submission
-  usethis::use_template(".make-targets.sh",
+  # Copy batch script for job submission. The main {targets} process has to run
+  # under the same R as the workers, so the runtime chooses the template.
+  make_targets_template <- switch(runtime,
+    container = ".make-targets.sh",
+    native = ".make-targets-native.sh"
+  )
+  usethis::use_template(make_targets_template,
                         save_as = ".make-targets.sh",
                         package = "levinmisc")
-  cli::cli_alert_success("Submission template created at {.file .make-targets.sh}")
+  cli::cli_alert_success("Submission template created at {.file .make-targets.sh} using the {.val {runtime}} R runtime")
 
   # Copy batch script to submit targets job
   usethis::use_template("submit-targets.sh",
@@ -50,7 +62,7 @@ populate_targets_proj <- function(title,
   # Copy targets pipeline template
   usethis::use_template("Pipeline.qmd",
                         save_as = paste0(title, "-Pipeline.qmd"),
-                        data = list(global_options = levinmisc::use_crew_lsf()),
+                        data = list(global_options = levinmisc::use_crew_lsf(runtime = runtime)),
                         package = "levinmisc")
   cli::cli_alert_success("Targets Pipeline template created at {.file {paste0(title, '-Pipeline.qmd')}}")
 

--- a/R/use_crew_lsf.R
+++ b/R/use_crew_lsf.R
@@ -7,9 +7,9 @@
 #' 
 #' This function returns a template for using `crew.cluster` in a targets project, enabling the parallel execution of a targets workflow. By default, the template is pre-filled using parameters specific to the LPC system at Penn. By default, this function creates workers that submit to different queues (eg. `voltron_normal`, `voltron_long`), and allocate different resources (eg. a "normal" worker will use 1 core and 16GB memory, while a "long" worker will use 1 core and 10GB memory).
 #'
-#' The `runtime` argument selects the R installation the workers run against. `"container"` runs each worker inside the LPC's RStudio Singularity image, and `"native"` loads the LPC's R module instead, leaving the package library to `renv`. Use `"native"` when the project library was built against a module-provided R: a worker that loads a library built for a different R version fails with errors such as `unused arguments (controller = ...)`, because the worker and the controller then run different `crew` versions.
+#' The `runtime` argument selects the R installation the workers run against. `"native"`, the default, loads the LPC's R module and leaves the package library to `renv`; `"container"` runs each worker inside the LPC's RStudio Singularity image instead. Use `"container"` only when the project library was built against that image: a worker that loads a library built for a different R version fails with errors such as `unused arguments (controller = ...)`, because the worker and the controller then run different `crew` versions.
 #'
-#' @param runtime (character) R runtime the LSF workers use: `"container"` for the LPC RStudio Singularity image, or `"native"` for the module-provided R
+#' @param runtime (character) R runtime the LSF workers use: `"native"` (the default) for the module-provided R, or `"container"` for the LPC RStudio Singularity image
 #'
 #' @return A code block to copy/paste into a targets project
 #'
@@ -18,10 +18,10 @@
 #' @examples
 #' \dontrun{
 #' use_crew_lsf()
-#' use_crew_lsf(runtime = "native")
+#' use_crew_lsf(runtime = "container")
 #' }
 
-use_crew_lsf <- function(runtime = c("container", "native")) {
+use_crew_lsf <- function(runtime = c("native", "container")) {
   runtime <- rlang::arg_match(runtime)
 
   title <- basename(here::here())
@@ -62,10 +62,10 @@ use_crew_lsf <- function(runtime = c("container", "native")) {
   }
 
   # A single `crew_controller_lsf()` call, rendered as the source the user
-  # pastes into their pipeline. The container runtime keeps the `lsf_*`
-  # arguments, which are what the crew.cluster build inside the image
-  # understands; the native runtime uses the current `crew_options_lsf()`
-  # interface that replaced them.
+  # pastes into their pipeline. The native runtime uses the current
+  # `crew_options_lsf()` interface; the container runtime keeps the `lsf_*`
+  # arguments it replaced, which are what the crew.cluster build inside the
+  # image understands.
   controller <- function(suffix, workers, queue, memory, threads = 1, cores = NULL) {
     if (runtime == "container") {
       glue::glue(

--- a/R/use_crew_lsf.R
+++ b/R/use_crew_lsf.R
@@ -7,6 +7,10 @@
 #' 
 #' This function returns a template for using `crew.cluster` in a targets project, enabling the parallel execution of a targets workflow. By default, the template is pre-filled using parameters specific to the LPC system at Penn. By default, this function creates workers that submit to different queues (eg. `voltron_normal`, `voltron_long`), and allocate different resources (eg. a "normal" worker will use 1 core and 16GB memory, while a "long" worker will use 1 core and 10GB memory).
 #'
+#' The `runtime` argument selects the R installation the workers run against. `"container"` runs each worker inside the LPC's RStudio Singularity image, and `"native"` loads the LPC's R module instead, leaving the package library to `renv`. Use `"native"` when the project library was built against a module-provided R: a worker that loads a library built for a different R version fails with errors such as `unused arguments (controller = ...)`, because the worker and the controller then run different `crew` versions.
+#'
+#' @param runtime (character) R runtime the LSF workers use: `"container"` for the LPC RStudio Singularity image, or `"native"` for the module-provided R
+#'
 #' @return A code block to copy/paste into a targets project
 #'
 #' @export
@@ -14,10 +18,91 @@
 #' @examples
 #' \dontrun{
 #' use_crew_lsf()
+#' use_crew_lsf(runtime = "native")
 #' }
 
-use_crew_lsf <- function() {
+use_crew_lsf <- function(runtime = c("container", "native")) {
+  runtime <- rlang::arg_match(runtime)
+
   title <- basename(here::here())
+
+  # The "container" runtime executes each worker inside the LPC's RStudio
+  # image, so `R_LIBS_USER` has to name a library built against that image's R.
+  # The "native" runtime loads the LPC's R module instead and leaves the library
+  # to `renv/activate.R`, because `crew_options_lsf()` defaults `cwd` to the
+  # directory the controllers were built in - the project directory.
+  container_image <- "/project/voltron/rstudio/containers/bioconductor-tidyverse_3.17.sif"
+  container_library <- "$HOME/R/rocker-rstudio/bioconductor-tidyverse_3.17"
+  container_bind <- "/project/:/project/, /appl/:/appl/, /lsf/:/lsf/, /scratch/:/scratch, /static:/static"
+  r_module <- "R/4.5"
+
+  # Shell lines that open each worker script, rendered as the elements of a
+  # `script_lines = c(...)` call. crew appends its own `Rscript -e '...'` after
+  # them, so under the container runtime the `singularity exec` line comes last
+  # and ends in a line continuation.
+  worker_lines <- function(queue, threads, indent) {
+    lines <- c(
+      paste0("#BSUB-q ", queue),
+      if (runtime == "container") {
+        paste0("export R_LIBS_USER=", container_library)
+      } else {
+        paste0("module load ", r_module)
+      },
+      "export TMPDIR=/scratch",
+      paste0("export OMP_NUM_THREADS=", threads),
+      if (runtime == "container") {
+        c(
+          paste0("export SINGULARITY_BIND='", container_bind, "'"),
+          paste0("singularity exec --pwd ", getwd(), " ", container_image, " \\")
+        )
+      }
+    )
+
+    paste0(strrep(" ", indent), encodeString(lines, quote = "\""), collapse = ",\n")
+  }
+
+  # A single `crew_controller_lsf()` call, rendered as the source the user
+  # pastes into their pipeline. The container runtime keeps the `lsf_*`
+  # arguments, which are what the crew.cluster build inside the image
+  # understands; the native runtime uses the current `crew_options_lsf()`
+  # interface that replaced them.
+  controller <- function(suffix, workers, queue, memory, threads = 1, cores = NULL) {
+    if (runtime == "container") {
+      glue::glue(
+        "controller_lsf_{suffix} <- crew.cluster::crew_controller_lsf(
+  name = '{title}_{suffix}',
+  workers = {workers}L,{cores_line}
+  lsf_memory_gigabytes_limit = {memory},
+  script_dir = tools::R_user_dir('crew.cluster', which = 'cache'),
+  lsf_log_output = 'build_logs/crew-%J.log',
+  lsf_log_error = 'build_logs/crew-%J.err',
+  script_lines = c(
+{worker_lines(queue, threads, indent = 4)}
+  ),
+  verbose = TRUE
+)",
+        cores_line = if (is.null(cores)) "" else paste0("\n  lsf_cores = ", cores, ",")
+      )
+    } else {
+      glue::glue(
+        "controller_lsf_{suffix} <- crew.cluster::crew_controller_lsf(
+  name = '{title}_{suffix}',
+  workers = {workers}L,
+  options_cluster = crew.cluster::crew_options_lsf(
+    verbose = TRUE,
+    script_directory = tools::R_user_dir('crew.cluster', which = 'cache'),
+    script_lines = c(
+{worker_lines(queue, threads, indent = 6)}
+    ),
+    log_output = 'build_logs/crew-%J.log',
+    log_error = 'build_logs/crew-%J.err',
+    memory_gigabytes_limit = {memory}{cores_line}
+  )
+)",
+        cores_line = if (is.null(cores)) "" else paste0(",\n    cores = ", cores)
+      )
+    }
+  }
 
   command <- glue::glue(
     "library(targets)
@@ -31,78 +116,13 @@ controller_local <- crew_controller_local(
   seconds_idle = 10
 )
 
-controller_lsf_normal <- crew.cluster::crew_controller_lsf(
-  name = '{title}_normal',
-  workers = 20L,
-  lsf_memory_gigabytes_limit = 16,
-  script_dir = tools::R_user_dir('crew.cluster', which = 'cache'),
-  lsf_log_output = 'build_logs/crew-%J.log',
-  lsf_log_error = 'build_logs/crew-%J.err',
-  script_lines = c(
-    \"#BSUB-q voltron_normal\",
-    \"export R_LIBS_USER=$HOME/R/rocker-rstudio/bioconductor-tidyverse_3.17\",
-    \"export TMPDIR=/scratch\",
-    \"export OMP_NUM_THREADS=1\",
-    \"export SINGULARITY_BIND='/project/:/project/, /appl/:/appl/, /lsf/:/lsf/, /scratch/:/scratch, /static:/static'\",
-    \"singularity exec --pwd {getwd()} /project/voltron/rstudio/containers/bioconductor-tidyverse_3.17.sif \\\\\"
-  ),
-  verbose = TRUE
-)
+{controller('normal', 20, 'voltron_normal', 16)}
 
-controller_lsf_long <- crew.cluster::crew_controller_lsf(
-  name = '{title}_long',
-  workers = 150L,
-  lsf_memory_gigabytes_limit = 10,
-  script_dir = tools::R_user_dir('crew.cluster', which = 'cache'),
-  lsf_log_output = 'build_logs/crew-%J.log',
-  lsf_log_error = 'build_logs/crew-%J.err',
-  script_lines = c(
-    \"#BSUB-q voltron_long\",
-    \"export R_LIBS_USER=$HOME/R/rocker-rstudio/bioconductor-tidyverse_3.17\",
-    \"export TMPDIR=/scratch\",
-    \"export OMP_NUM_THREADS=1\",
-    \"export SINGULARITY_BIND='/project/:/project/, /appl/:/appl/, /lsf/:/lsf/, /scratch/:/scratch, /static:/static'\",
-    \"singularity exec --pwd {getwd()} /project/voltron/rstudio/containers/bioconductor-tidyverse_3.17.sif \\\\\"
-  ),
-  verbose = TRUE
-)
+{controller('long', 150, 'voltron_long', 10)}
 
-controller_lsf_highmem <- crew.cluster::crew_controller_lsf(
-  name = '{title}_highmem',
-  workers = 5L,
-  lsf_memory_gigabytes_limit = 96,
-  script_dir = tools::R_user_dir('crew.cluster', which = 'cache'),
-  lsf_log_output = 'build_logs/crew-%J.log',
-  lsf_log_error = 'build_logs/crew-%J.err',
-  script_lines = c(
-    \"#BSUB-q voltron_normal\",
-    \"export R_LIBS_USER=$HOME/R/rocker-rstudio/bioconductor-tidyverse_3.17\",
-    \"export TMPDIR=/scratch\",
-    \"export OMP_NUM_THREADS=1\",
-    \"export SINGULARITY_BIND='/project/:/project/, /appl/:/appl/, /lsf/:/lsf/, /scratch/:/scratch, /static:/static'\",
-    \"singularity exec --pwd {getwd()} /project/voltron/rstudio/containers/bioconductor-tidyverse_3.17.sif \\\\\"
-  ),
-  verbose = TRUE
-)
+{controller('highmem', 5, 'voltron_normal', 96)}
 
-controller_lsf_multicore <- crew.cluster::crew_controller_lsf(
-  name = '{title}_multicore',
-  workers = 5L,
-  lsf_cores = 16,
-  lsf_memory_gigabytes_limit = 96,
-  script_dir = tools::R_user_dir('crew.cluster', which = 'cache'),
-  lsf_log_output = 'build_logs/crew-%J.log',
-  lsf_log_error = 'build_logs/crew-%J.err',
-  script_lines = c(
-    \"#BSUB-q voltron_normal\",
-    \"export R_LIBS_USER=$HOME/R/rocker-rstudio/bioconductor-tidyverse_3.17\",
-    \"export TMPDIR=/scratch\",
-    \"export OMP_NUM_THREADS=16\",
-    \"export SINGULARITY_BIND='/project/:/project/, /appl/:/appl/, /lsf/:/lsf/, /scratch/:/scratch, /static:/static'\",
-    \"singularity exec --pwd {getwd()} /project/voltron/rstudio/containers/bioconductor-tidyverse_3.17.sif \\\\\"
-  ),
-  verbose = TRUE
-)
+{controller('multicore', 5, 'voltron_normal', 96, threads = 16, cores = 16)}
 
 # define some global options/functions common to all targets
 options(tidyverse.quiet = TRUE)

--- a/dev/LPC_targets_project.Rmd
+++ b/dev/LPC_targets_project.Rmd
@@ -64,14 +64,19 @@ The `targets` package is a tool for developing reproducible research workflows i
 
 The `populate_targets_proj` function can be run within a new project folder to initialize the project with the files/folders necessary for deploying a `targets` pipeline on the LPC at Penn. This includes creating LSF templates, a `Pipelines.qmd` file containing boilerplate for running analyses, and a `Results.qmd` file which can be used to visualize the results.
 
+The `runtime` argument chooses the R installation the pipeline runs against. `"container"` (the default) runs the main `targets` process and every LSF worker inside the LPC's RStudio Singularity image, reading packages from a library built against that image's R. `"native"` loads the LPC's R module (`module load R/4.5`) instead and leaves the package library to `renv`, which is the right choice for a project whose library was built against a module-provided R. Mixing the two fails at run time: a worker that loads a library built for a different R version reports errors such as `unused arguments (controller = ...)`, because the worker and the controller end up running different `crew` versions.
+
 ```{r function-populate_targets_proj}
 #' Create a minimal targets template in the current project
 #' 
 #' @description
 #' This function creates a minimal targets template in the current directory. This includes creating a `Pipelines.qmd` file containing boilerplate for running analyses, and a `Results.qmd` file which can be used to visualize the results. Parallelization of the pipeline is implemented using [targets::tar_make()] and `crew.cluster`, using pre-filled using parameters specific to the LPC system at Penn.
 #'
+#' The `runtime` argument selects the R installation the pipeline runs against, and is passed through to [use_crew_lsf()]. `"container"` runs the main `targets` process and every worker inside the LPC's RStudio Singularity image; `"native"` loads the LPC's R module instead and leaves the package library to `renv`.
+#'
 #' @param title (character) base name for project files (eg. "{title}-Pipeline.qmd" and "{title}-Results.qmd")
 #' @param log_folder (character) directory for LSF logs
+#' @param runtime (character) R runtime the pipeline and its LSF workers use: `"container"` for the LPC RStudio Singularity image, or `"native"` for the module-provided R
 #' @param overwrite (logical) overwrite existing template files
 #'
 #' @export
@@ -79,7 +84,10 @@ The `populate_targets_proj` function can be run within a new project folder to i
 
 populate_targets_proj <- function(title,
                                   log_folder = "build_logs",
+                                  runtime = c("container", "native"),
                                   overwrite = FALSE) {
+  runtime <- rlang::arg_match(runtime)
+
   # Create title
   if (missing(title)) {
     title <- basename(here::here())
@@ -96,11 +104,16 @@ populate_targets_proj <- function(title,
   fs::dir_create(log_folder)
   cli::cli_alert_success("Build log folder created at {.file {log_folder}}")
 
-  # Copy batch script for job submission
-  usethis::use_template(".make-targets.sh",
+  # Copy batch script for job submission. The main {targets} process has to run
+  # under the same R as the workers, so the runtime chooses the template.
+  make_targets_template <- switch(runtime,
+    container = ".make-targets.sh",
+    native = ".make-targets-native.sh"
+  )
+  usethis::use_template(make_targets_template,
                         save_as = ".make-targets.sh",
                         package = "levinmisc")
-  cli::cli_alert_success("Submission template created at {.file .make-targets.sh}")
+  cli::cli_alert_success("Submission template created at {.file .make-targets.sh} using the {.val {runtime}} R runtime")
 
   # Copy batch script to submit targets job
   usethis::use_template("submit-targets.sh",
@@ -111,7 +124,7 @@ populate_targets_proj <- function(title,
   # Copy targets pipeline template
   usethis::use_template("Pipeline.qmd",
                         save_as = paste0(title, "-Pipeline.qmd"),
-                        data = list(global_options = levinmisc::use_crew_lsf()),
+                        data = list(global_options = levinmisc::use_crew_lsf(runtime = runtime)),
                         package = "levinmisc")
   cli::cli_alert_success("Targets Pipeline template created at {.file {paste0(title, '-Pipeline.qmd')}}")
 
@@ -131,10 +144,11 @@ This should be a reproducible and working example
 ```{r examples-populate_targets_proj, eval=FALSE}
 #' \dontrun{
 populate_targets_proj("test")
+populate_targets_proj("test", runtime = "native")
 #' }
 ```
 
-The `populate_targets_proj()` function creates several files/folders within the project directory. `.make-targets.sh` and is a hidden helper file which is not designed for user interaction, but necessary for submission of jobs to the LSF scheduler. The other files are designed to be edited/used by the user:
+The `populate_targets_proj()` function creates several files/folders within the project directory. `.make-targets.sh` and is a hidden helper file which is not designed for user interaction, but necessary for submission of jobs to the LSF scheduler; its contents follow the `runtime` argument, so that the main `targets` process runs under the same R as the workers. The other files are designed to be edited/used by the user:
 
   - `Pipeline.qmd` - Quarto markdown file which can be used to create a Target Markdown document that specifies a `targets` pipeline for your analyses. See: https://books.ropensci.org/targets/literate-programming.html#target-markdown for details. Remember to knit/render this document in order to generate the pipeline.
   
@@ -232,6 +246,8 @@ test_that("populate_targets_proj works", {
 ### Use {crew} for parallelization
 
 The `crew` and `crew.cluster` packages have enabled the use of heterogenous workers (<https://books.ropensci.org/targets/crew.html#heterogeneous-workers>), that can be used to deploy `targets` pipelines either locally or on HPC resources. The `use_crew_lsf()` function is designed to return a block of code to rapidly enable the use of heterogeneous workers on the Penn LPC. By default, this function creates workers that submit to different queues (eg. `voltron_normal`, `voltron_long`), and allocate different resources (eg. a "normal" worker will use 1 core and 16GB memory, while a "long" worker will use 1 core and 10GB memory).
+
+`use_crew_lsf()` takes the same `runtime` argument as `populate_targets_proj()`, which controls the shell lines that open each worker script. Under `"container"` the worker exports `R_LIBS_USER` and `SINGULARITY_BIND` and then runs R through `singularity exec`; under `"native"` it runs `module load R/4.5` and nothing else, so the project library comes from `renv/activate.R` (`crew_options_lsf()` defaults `cwd` to the project directory). The two branches also differ in the `crew.cluster` interface they emit: the container branch keeps the older `lsf_*` arguments to `crew_controller_lsf()`, which is what the `crew.cluster` build inside the image understands, while the native branch uses the `crew_options_lsf()` interface that replaced them.
     
 ```{r function-use_crew_lsf}
 #' Use crew lsf to execute a targets pipeline using the LSF HPC scheduler
@@ -241,13 +257,97 @@ The `crew` and `crew.cluster` packages have enabled the use of heterogenous work
 #' 
 #' This function returns a template for using `crew.cluster` in a targets project, enabling the parallel execution of a targets workflow. By default, the template is pre-filled using parameters specific to the LPC system at Penn. By default, this function creates workers that submit to different queues (eg. `voltron_normal`, `voltron_long`), and allocate different resources (eg. a "normal" worker will use 1 core and 16GB memory, while a "long" worker will use 1 core and 10GB memory).
 #'
+#' The `runtime` argument selects the R installation the workers run against. `"container"` runs each worker inside the LPC's RStudio Singularity image, and `"native"` loads the LPC's R module instead, leaving the package library to `renv`. Use `"native"` when the project library was built against a module-provided R: a worker that loads a library built for a different R version fails with errors such as `unused arguments (controller = ...)`, because the worker and the controller then run different `crew` versions.
+#'
+#' @param runtime (character) R runtime the LSF workers use: `"container"` for the LPC RStudio Singularity image, or `"native"` for the module-provided R
+#'
 #' @return A code block to copy/paste into a targets project
 #'
 #' @export
 #' @concept targets
 
-use_crew_lsf <- function() {
+use_crew_lsf <- function(runtime = c("container", "native")) {
+  runtime <- rlang::arg_match(runtime)
+
   title <- basename(here::here())
+
+  # The "container" runtime executes each worker inside the LPC's RStudio
+  # image, so `R_LIBS_USER` has to name a library built against that image's R.
+  # The "native" runtime loads the LPC's R module instead and leaves the library
+  # to `renv/activate.R`, because `crew_options_lsf()` defaults `cwd` to the
+  # directory the controllers were built in - the project directory.
+  container_image <- "/project/voltron/rstudio/containers/bioconductor-tidyverse_3.17.sif"
+  container_library <- "$HOME/R/rocker-rstudio/bioconductor-tidyverse_3.17"
+  container_bind <- "/project/:/project/, /appl/:/appl/, /lsf/:/lsf/, /scratch/:/scratch, /static:/static"
+  r_module <- "R/4.5"
+
+  # Shell lines that open each worker script, rendered as the elements of a
+  # `script_lines = c(...)` call. crew appends its own `Rscript -e '...'` after
+  # them, so under the container runtime the `singularity exec` line comes last
+  # and ends in a line continuation.
+  worker_lines <- function(queue, threads, indent) {
+    lines <- c(
+      paste0("#BSUB-q ", queue),
+      if (runtime == "container") {
+        paste0("export R_LIBS_USER=", container_library)
+      } else {
+        paste0("module load ", r_module)
+      },
+      "export TMPDIR=/scratch",
+      paste0("export OMP_NUM_THREADS=", threads),
+      if (runtime == "container") {
+        c(
+          paste0("export SINGULARITY_BIND='", container_bind, "'"),
+          paste0("singularity exec --pwd ", getwd(), " ", container_image, " \\")
+        )
+      }
+    )
+
+    paste0(strrep(" ", indent), encodeString(lines, quote = "\""), collapse = ",\n")
+  }
+
+  # A single `crew_controller_lsf()` call, rendered as the source the user
+  # pastes into their pipeline. The container runtime keeps the `lsf_*`
+  # arguments, which are what the crew.cluster build inside the image
+  # understands; the native runtime uses the current `crew_options_lsf()`
+  # interface that replaced them.
+  controller <- function(suffix, workers, queue, memory, threads = 1, cores = NULL) {
+    if (runtime == "container") {
+      glue::glue(
+        "controller_lsf_{suffix} <- crew.cluster::crew_controller_lsf(
+  name = '{title}_{suffix}',
+  workers = {workers}L,{cores_line}
+  lsf_memory_gigabytes_limit = {memory},
+  script_dir = tools::R_user_dir('crew.cluster', which = 'cache'),
+  lsf_log_output = 'build_logs/crew-%J.log',
+  lsf_log_error = 'build_logs/crew-%J.err',
+  script_lines = c(
+{worker_lines(queue, threads, indent = 4)}
+  ),
+  verbose = TRUE
+)",
+        cores_line = if (is.null(cores)) "" else paste0("\n  lsf_cores = ", cores, ",")
+      )
+    } else {
+      glue::glue(
+        "controller_lsf_{suffix} <- crew.cluster::crew_controller_lsf(
+  name = '{title}_{suffix}',
+  workers = {workers}L,
+  options_cluster = crew.cluster::crew_options_lsf(
+    verbose = TRUE,
+    script_directory = tools::R_user_dir('crew.cluster', which = 'cache'),
+    script_lines = c(
+{worker_lines(queue, threads, indent = 6)}
+    ),
+    log_output = 'build_logs/crew-%J.log',
+    log_error = 'build_logs/crew-%J.err',
+    memory_gigabytes_limit = {memory}{cores_line}
+  )
+)",
+        cores_line = if (is.null(cores)) "" else paste0(",\n    cores = ", cores)
+      )
+    }
+  }
 
   command <- glue::glue(
     "library(targets)
@@ -261,78 +361,13 @@ controller_local <- crew_controller_local(
   seconds_idle = 10
 )
 
-controller_lsf_normal <- crew.cluster::crew_controller_lsf(
-  name = '{title}_normal',
-  workers = 20L,
-  lsf_memory_gigabytes_limit = 16,
-  script_dir = tools::R_user_dir('crew.cluster', which = 'cache'),
-  lsf_log_output = 'build_logs/crew-%J.log',
-  lsf_log_error = 'build_logs/crew-%J.err',
-  script_lines = c(
-    \"#BSUB-q voltron_normal\",
-    \"export R_LIBS_USER=$HOME/R/rocker-rstudio/bioconductor-tidyverse_3.17\",
-    \"export TMPDIR=/scratch\",
-    \"export OMP_NUM_THREADS=1\",
-    \"export SINGULARITY_BIND='/project/:/project/, /appl/:/appl/, /lsf/:/lsf/, /scratch/:/scratch, /static:/static'\",
-    \"singularity exec --pwd {getwd()} /project/voltron/rstudio/containers/bioconductor-tidyverse_3.17.sif \\\\\"
-  ),
-  verbose = TRUE
-)
+{controller('normal', 20, 'voltron_normal', 16)}
 
-controller_lsf_long <- crew.cluster::crew_controller_lsf(
-  name = '{title}_long',
-  workers = 150L,
-  lsf_memory_gigabytes_limit = 10,
-  script_dir = tools::R_user_dir('crew.cluster', which = 'cache'),
-  lsf_log_output = 'build_logs/crew-%J.log',
-  lsf_log_error = 'build_logs/crew-%J.err',
-  script_lines = c(
-    \"#BSUB-q voltron_long\",
-    \"export R_LIBS_USER=$HOME/R/rocker-rstudio/bioconductor-tidyverse_3.17\",
-    \"export TMPDIR=/scratch\",
-    \"export OMP_NUM_THREADS=1\",
-    \"export SINGULARITY_BIND='/project/:/project/, /appl/:/appl/, /lsf/:/lsf/, /scratch/:/scratch, /static:/static'\",
-    \"singularity exec --pwd {getwd()} /project/voltron/rstudio/containers/bioconductor-tidyverse_3.17.sif \\\\\"
-  ),
-  verbose = TRUE
-)
+{controller('long', 150, 'voltron_long', 10)}
 
-controller_lsf_highmem <- crew.cluster::crew_controller_lsf(
-  name = '{title}_highmem',
-  workers = 5L,
-  lsf_memory_gigabytes_limit = 96,
-  script_dir = tools::R_user_dir('crew.cluster', which = 'cache'),
-  lsf_log_output = 'build_logs/crew-%J.log',
-  lsf_log_error = 'build_logs/crew-%J.err',
-  script_lines = c(
-    \"#BSUB-q voltron_normal\",
-    \"export R_LIBS_USER=$HOME/R/rocker-rstudio/bioconductor-tidyverse_3.17\",
-    \"export TMPDIR=/scratch\",
-    \"export OMP_NUM_THREADS=1\",
-    \"export SINGULARITY_BIND='/project/:/project/, /appl/:/appl/, /lsf/:/lsf/, /scratch/:/scratch, /static:/static'\",
-    \"singularity exec --pwd {getwd()} /project/voltron/rstudio/containers/bioconductor-tidyverse_3.17.sif \\\\\"
-  ),
-  verbose = TRUE
-)
+{controller('highmem', 5, 'voltron_normal', 96)}
 
-controller_lsf_multicore <- crew.cluster::crew_controller_lsf(
-  name = '{title}_multicore',
-  workers = 5L,
-  lsf_cores = 16,
-  lsf_memory_gigabytes_limit = 96,
-  script_dir = tools::R_user_dir('crew.cluster', which = 'cache'),
-  lsf_log_output = 'build_logs/crew-%J.log',
-  lsf_log_error = 'build_logs/crew-%J.err',
-  script_lines = c(
-    \"#BSUB-q voltron_normal\",
-    \"export R_LIBS_USER=$HOME/R/rocker-rstudio/bioconductor-tidyverse_3.17\",
-    \"export TMPDIR=/scratch\",
-    \"export OMP_NUM_THREADS=16\",
-    \"export SINGULARITY_BIND='/project/:/project/, /appl/:/appl/, /lsf/:/lsf/, /scratch/:/scratch, /static:/static'\",
-    \"singularity exec --pwd {getwd()} /project/voltron/rstudio/containers/bioconductor-tidyverse_3.17.sif \\\\\"
-  ),
-  verbose = TRUE
-)
+{controller('multicore', 5, 'voltron_normal', 96, threads = 16, cores = 16)}
 
 # define some global options/functions common to all targets
 options(tidyverse.quiet = TRUE)
@@ -359,12 +394,42 @@ tar_option_set(
 ```{r example-use_crew_lsf, eval=FALSE}
 #' \dontrun{
 use_crew_lsf()
+use_crew_lsf(runtime = "native")
 #' }
 ```
   
 ```{r tests-use_crew_lsf}
 test_that("use_crew_lsf works", {
   expect_true(inherits(use_crew_lsf, "function"))
+})
+
+test_that("use_crew_lsf defaults to the container runtime", {
+  template <- suppressMessages(use_crew_lsf())
+  expect_identical(
+    as.character(template),
+    as.character(suppressMessages(use_crew_lsf(runtime = "container")))
+  )
+  expect_true(grepl("singularity exec", template, fixed = TRUE))
+  expect_true(grepl("export SINGULARITY_BIND=", template, fixed = TRUE))
+  expect_false(grepl("module load", template, fixed = TRUE))
+})
+
+test_that("use_crew_lsf loads an R module under the native runtime", {
+  template <- suppressMessages(use_crew_lsf(runtime = "native"))
+  expect_true(grepl("module load R/", template, fixed = TRUE))
+  expect_false(grepl("singularity exec", template, fixed = TRUE))
+  expect_false(grepl("R_LIBS_USER", template, fixed = TRUE))
+})
+
+test_that("use_crew_lsf returns parseable R code for either runtime", {
+  for (runtime in c("container", "native")) {
+    template <- suppressMessages(use_crew_lsf(runtime = runtime))
+    expect_true(length(parse(text = template)) > 0)
+  }
+})
+
+test_that("use_crew_lsf rejects an unknown runtime", {
+  expect_error(use_crew_lsf(runtime = "singularity"), "must be one of")
 })
 ```
   

--- a/dev/LPC_targets_project.Rmd
+++ b/dev/LPC_targets_project.Rmd
@@ -64,7 +64,7 @@ The `targets` package is a tool for developing reproducible research workflows i
 
 The `populate_targets_proj` function can be run within a new project folder to initialize the project with the files/folders necessary for deploying a `targets` pipeline on the LPC at Penn. This includes creating LSF templates, a `Pipelines.qmd` file containing boilerplate for running analyses, and a `Results.qmd` file which can be used to visualize the results.
 
-The `runtime` argument chooses the R installation the pipeline runs against. `"container"` (the default) runs the main `targets` process and every LSF worker inside the LPC's RStudio Singularity image, reading packages from a library built against that image's R. `"native"` loads the LPC's R module (`module load R/4.5`) instead and leaves the package library to `renv`, which is the right choice for a project whose library was built against a module-provided R. Mixing the two fails at run time: a worker that loads a library built for a different R version reports errors such as `unused arguments (controller = ...)`, because the worker and the controller end up running different `crew` versions.
+The `runtime` argument chooses the R installation the pipeline runs against. `"native"` (the default) loads the LPC's R module (`module load R/4.5`) and leaves the package library to `renv`. `"container"` instead runs the main `targets` process and every LSF worker inside the LPC's RStudio Singularity image, reading packages from a library built against that image's R, which is the right choice only for a project whose library was built against that image. Mixing the two fails at run time: a worker that loads a library built for a different R version reports errors such as `unused arguments (controller = ...)`, because the worker and the controller end up running different `crew` versions.
 
 ```{r function-populate_targets_proj}
 #' Create a minimal targets template in the current project
@@ -72,11 +72,11 @@ The `runtime` argument chooses the R installation the pipeline runs against. `"c
 #' @description
 #' This function creates a minimal targets template in the current directory. This includes creating a `Pipelines.qmd` file containing boilerplate for running analyses, and a `Results.qmd` file which can be used to visualize the results. Parallelization of the pipeline is implemented using [targets::tar_make()] and `crew.cluster`, using pre-filled using parameters specific to the LPC system at Penn.
 #'
-#' The `runtime` argument selects the R installation the pipeline runs against, and is passed through to [use_crew_lsf()]. `"container"` runs the main `targets` process and every worker inside the LPC's RStudio Singularity image; `"native"` loads the LPC's R module instead and leaves the package library to `renv`.
+#' The `runtime` argument selects the R installation the pipeline runs against, and is passed through to [use_crew_lsf()]. `"native"`, the default, loads the LPC's R module and leaves the package library to `renv`; `"container"` instead runs the main `targets` process and every worker inside the LPC's RStudio Singularity image.
 #'
 #' @param title (character) base name for project files (eg. "{title}-Pipeline.qmd" and "{title}-Results.qmd")
 #' @param log_folder (character) directory for LSF logs
-#' @param runtime (character) R runtime the pipeline and its LSF workers use: `"container"` for the LPC RStudio Singularity image, or `"native"` for the module-provided R
+#' @param runtime (character) R runtime the pipeline and its LSF workers use: `"native"` (the default) for the module-provided R, or `"container"` for the LPC RStudio Singularity image
 #' @param overwrite (logical) overwrite existing template files
 #'
 #' @export
@@ -84,7 +84,7 @@ The `runtime` argument chooses the R installation the pipeline runs against. `"c
 
 populate_targets_proj <- function(title,
                                   log_folder = "build_logs",
-                                  runtime = c("container", "native"),
+                                  runtime = c("native", "container"),
                                   overwrite = FALSE) {
   runtime <- rlang::arg_match(runtime)
 
@@ -144,7 +144,7 @@ This should be a reproducible and working example
 ```{r examples-populate_targets_proj, eval=FALSE}
 #' \dontrun{
 populate_targets_proj("test")
-populate_targets_proj("test", runtime = "native")
+populate_targets_proj("test", runtime = "container")
 #' }
 ```
 
@@ -257,16 +257,16 @@ The `crew` and `crew.cluster` packages have enabled the use of heterogenous work
 #' 
 #' This function returns a template for using `crew.cluster` in a targets project, enabling the parallel execution of a targets workflow. By default, the template is pre-filled using parameters specific to the LPC system at Penn. By default, this function creates workers that submit to different queues (eg. `voltron_normal`, `voltron_long`), and allocate different resources (eg. a "normal" worker will use 1 core and 16GB memory, while a "long" worker will use 1 core and 10GB memory).
 #'
-#' The `runtime` argument selects the R installation the workers run against. `"container"` runs each worker inside the LPC's RStudio Singularity image, and `"native"` loads the LPC's R module instead, leaving the package library to `renv`. Use `"native"` when the project library was built against a module-provided R: a worker that loads a library built for a different R version fails with errors such as `unused arguments (controller = ...)`, because the worker and the controller then run different `crew` versions.
+#' The `runtime` argument selects the R installation the workers run against. `"native"`, the default, loads the LPC's R module and leaves the package library to `renv`; `"container"` runs each worker inside the LPC's RStudio Singularity image instead. Use `"container"` only when the project library was built against that image: a worker that loads a library built for a different R version fails with errors such as `unused arguments (controller = ...)`, because the worker and the controller then run different `crew` versions.
 #'
-#' @param runtime (character) R runtime the LSF workers use: `"container"` for the LPC RStudio Singularity image, or `"native"` for the module-provided R
+#' @param runtime (character) R runtime the LSF workers use: `"native"` (the default) for the module-provided R, or `"container"` for the LPC RStudio Singularity image
 #'
 #' @return A code block to copy/paste into a targets project
 #'
 #' @export
 #' @concept targets
 
-use_crew_lsf <- function(runtime = c("container", "native")) {
+use_crew_lsf <- function(runtime = c("native", "container")) {
   runtime <- rlang::arg_match(runtime)
 
   title <- basename(here::here())
@@ -307,10 +307,10 @@ use_crew_lsf <- function(runtime = c("container", "native")) {
   }
 
   # A single `crew_controller_lsf()` call, rendered as the source the user
-  # pastes into their pipeline. The container runtime keeps the `lsf_*`
-  # arguments, which are what the crew.cluster build inside the image
-  # understands; the native runtime uses the current `crew_options_lsf()`
-  # interface that replaced them.
+  # pastes into their pipeline. The native runtime uses the current
+  # `crew_options_lsf()` interface; the container runtime keeps the `lsf_*`
+  # arguments it replaced, which are what the crew.cluster build inside the
+  # image understands.
   controller <- function(suffix, workers, queue, memory, threads = 1, cores = NULL) {
     if (runtime == "container") {
       glue::glue(
@@ -394,7 +394,7 @@ tar_option_set(
 ```{r example-use_crew_lsf, eval=FALSE}
 #' \dontrun{
 use_crew_lsf()
-use_crew_lsf(runtime = "native")
+use_crew_lsf(runtime = "container")
 #' }
 ```
   
@@ -403,22 +403,22 @@ test_that("use_crew_lsf works", {
   expect_true(inherits(use_crew_lsf, "function"))
 })
 
-test_that("use_crew_lsf defaults to the container runtime", {
+test_that("use_crew_lsf defaults to the native runtime", {
   template <- suppressMessages(use_crew_lsf())
   expect_identical(
     as.character(template),
-    as.character(suppressMessages(use_crew_lsf(runtime = "container")))
+    as.character(suppressMessages(use_crew_lsf(runtime = "native")))
   )
-  expect_true(grepl("singularity exec", template, fixed = TRUE))
-  expect_true(grepl("export SINGULARITY_BIND=", template, fixed = TRUE))
-  expect_false(grepl("module load", template, fixed = TRUE))
-})
-
-test_that("use_crew_lsf loads an R module under the native runtime", {
-  template <- suppressMessages(use_crew_lsf(runtime = "native"))
   expect_true(grepl("module load R/", template, fixed = TRUE))
   expect_false(grepl("singularity exec", template, fixed = TRUE))
   expect_false(grepl("R_LIBS_USER", template, fixed = TRUE))
+})
+
+test_that("use_crew_lsf runs workers in the image under the container runtime", {
+  template <- suppressMessages(use_crew_lsf(runtime = "container"))
+  expect_true(grepl("singularity exec", template, fixed = TRUE))
+  expect_true(grepl("export SINGULARITY_BIND=", template, fixed = TRUE))
+  expect_false(grepl("module load", template, fixed = TRUE))
 })
 
 test_that("use_crew_lsf returns parseable R code for either runtime", {

--- a/inst/templates/.make-targets-native.sh
+++ b/inst/templates/.make-targets-native.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+# Runs the main {targets} process against the LPC's native R rather than inside
+# the RStudio Singularity container. crew launches the workers from within the
+# pipeline itself, so this script only has to put the right R on PATH; the
+# project library then follows from renv/activate.R, because the job runs in the
+# project directory.
+
+# Initialize variables with default values
+slack=false
+num_cpus=1
+
+# Parse command line arguments
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -n)
+            shift
+            num_cpus=$1
+            ;;
+        -s)
+            shift
+            if [[ "$1" == "true" ]]; then
+                slack=true
+            fi
+            ;;
+        *)
+            echo "Usage: $0 [-n NUM_CPUS] [-s true/false]"
+            exit 1
+            ;;
+    esac
+    shift
+done
+
+# Check that the required arguments were provided
+if [[ -z "$num_cpus" ]]; then
+    echo "Usage: $0 [-n NUM_CPUS] [-s true/false]"
+    exit 1
+fi
+
+# num_cpus is accepted so that submit-targets.sh can pass it unconditionally,
+# but crew takes its worker counts from the controllers defined in the pipeline,
+# so it is not used here.
+
+module load R/4.5
+
+export TMPDIR=/scratch
+export R_WORK_DIR=$(pwd)
+
+if $slack; then
+  R --no-save --no-restore -e "slackr::slackr_setup(); slackr::slackr_bot('Targets Pipeline Started'); targets::tar_make(); slackr::slackr_bot('Targets Pipeline Complete')"
+else
+  R --no-save --no-restore -e "targets::tar_make()"
+fi

--- a/man/populate_targets_proj.Rd
+++ b/man/populate_targets_proj.Rd
@@ -7,7 +7,7 @@
 populate_targets_proj(
   title,
   log_folder = "build_logs",
-  runtime = c("container", "native"),
+  runtime = c("native", "container"),
   overwrite = FALSE
 )
 }
@@ -16,19 +16,19 @@ populate_targets_proj(
 
 \item{log_folder}{(character) directory for LSF logs}
 
-\item{runtime}{(character) R runtime the pipeline and its LSF workers use: \code{"container"} for the LPC RStudio Singularity image, or \code{"native"} for the module-provided R}
+\item{runtime}{(character) R runtime the pipeline and its LSF workers use: \code{"native"} (the default) for the module-provided R, or \code{"container"} for the LPC RStudio Singularity image}
 
 \item{overwrite}{(logical) overwrite existing template files}
 }
 \description{
 This function creates a minimal targets template in the current directory. This includes creating a \code{Pipelines.qmd} file containing boilerplate for running analyses, and a \code{Results.qmd} file which can be used to visualize the results. Parallelization of the pipeline is implemented using \code{\link[targets:tar_make]{targets::tar_make()}} and \code{crew.cluster}, using pre-filled using parameters specific to the LPC system at Penn.
 
-The \code{runtime} argument selects the R installation the pipeline runs against, and is passed through to \code{\link[=use_crew_lsf]{use_crew_lsf()}}. \code{"container"} runs the main \code{targets} process and every worker inside the LPC's RStudio Singularity image; \code{"native"} loads the LPC's R module instead and leaves the package library to \code{renv}.
+The \code{runtime} argument selects the R installation the pipeline runs against, and is passed through to \code{\link[=use_crew_lsf]{use_crew_lsf()}}. \code{"native"}, the default, loads the LPC's R module and leaves the package library to \code{renv}; \code{"container"} instead runs the main \code{targets} process and every worker inside the LPC's RStudio Singularity image.
 }
 \examples{
 \dontrun{
 populate_targets_proj("test")
-populate_targets_proj("test", runtime = "native")
+populate_targets_proj("test", runtime = "container")
 }
 }
 \concept{targets}

--- a/man/populate_targets_proj.Rd
+++ b/man/populate_targets_proj.Rd
@@ -4,21 +4,31 @@
 \alias{populate_targets_proj}
 \title{Create a minimal targets template in the current project}
 \usage{
-populate_targets_proj(title, log_folder = "build_logs", overwrite = FALSE)
+populate_targets_proj(
+  title,
+  log_folder = "build_logs",
+  runtime = c("container", "native"),
+  overwrite = FALSE
+)
 }
 \arguments{
 \item{title}{(character) base name for project files (eg. "{title}-Pipeline.qmd" and "{title}-Results.qmd")}
 
 \item{log_folder}{(character) directory for LSF logs}
 
+\item{runtime}{(character) R runtime the pipeline and its LSF workers use: \code{"container"} for the LPC RStudio Singularity image, or \code{"native"} for the module-provided R}
+
 \item{overwrite}{(logical) overwrite existing template files}
 }
 \description{
 This function creates a minimal targets template in the current directory. This includes creating a \code{Pipelines.qmd} file containing boilerplate for running analyses, and a \code{Results.qmd} file which can be used to visualize the results. Parallelization of the pipeline is implemented using \code{\link[targets:tar_make]{targets::tar_make()}} and \code{crew.cluster}, using pre-filled using parameters specific to the LPC system at Penn.
+
+The \code{runtime} argument selects the R installation the pipeline runs against, and is passed through to \code{\link[=use_crew_lsf]{use_crew_lsf()}}. \code{"container"} runs the main \code{targets} process and every worker inside the LPC's RStudio Singularity image; \code{"native"} loads the LPC's R module instead and leaves the package library to \code{renv}.
 }
 \examples{
 \dontrun{
 populate_targets_proj("test")
+populate_targets_proj("test", runtime = "native")
 }
 }
 \concept{targets}

--- a/man/use_crew_lsf.Rd
+++ b/man/use_crew_lsf.Rd
@@ -17,7 +17,7 @@ A code block to copy/paste into a targets project
 
 This function returns a template for using \code{crew.cluster} in a targets project, enabling the parallel execution of a targets workflow. By default, the template is pre-filled using parameters specific to the LPC system at Penn. By default, this function creates workers that submit to different queues (eg. \code{voltron_normal}, \code{voltron_long}), and allocate different resources (eg. a "normal" worker will use 1 core and 16GB memory, while a "long" worker will use 1 core and 10GB memory).
 
-The \code{runtime} argument selects the R installation the workers run against. \code{"native"}, the default, loads the LPC's R module and leaves the package library to \code{renv}; \code{"container"} runs each worker inside the LPC's RStudio Singularity image instead. Use \code{"container"} only when the project library was built against that image: a worker that loads a library built for a different R version fails with errors such as \code{unused arguments (controller = ...)}, because the worker and the controller then run different \code{crew} versions.
+The \code{runtime} argument selects the R installation the workers run against. \code{"native"}, the default, loads the LPC's R module and leaves the package library to \code{renv}; \code{"container"} runs each worker inside the LPC's RStudio Singularity image instead. Use \code{"container"} only when the project library was built against that image: a worker that loads a library built for a different R version fails with errors such as \verb{unused arguments (controller = ...)}, because the worker and the controller then run different \code{crew} versions.
 }
 \examples{
 \dontrun{

--- a/man/use_crew_lsf.Rd
+++ b/man/use_crew_lsf.Rd
@@ -4,7 +4,10 @@
 \alias{use_crew_lsf}
 \title{Use crew lsf to execute a targets pipeline using the LSF HPC scheduler}
 \usage{
-use_crew_lsf()
+use_crew_lsf(runtime = c("container", "native"))
+}
+\arguments{
+\item{runtime}{(character) R runtime the LSF workers use: \code{"container"} for the LPC RStudio Singularity image, or \code{"native"} for the module-provided R}
 }
 \value{
 A code block to copy/paste into a targets project
@@ -13,10 +16,13 @@ A code block to copy/paste into a targets project
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}
 
 This function returns a template for using \code{crew.cluster} in a targets project, enabling the parallel execution of a targets workflow. By default, the template is pre-filled using parameters specific to the LPC system at Penn. By default, this function creates workers that submit to different queues (eg. \code{voltron_normal}, \code{voltron_long}), and allocate different resources (eg. a "normal" worker will use 1 core and 16GB memory, while a "long" worker will use 1 core and 10GB memory).
+
+The \code{runtime} argument selects the R installation the workers run against. \code{"container"} runs each worker inside the LPC's RStudio Singularity image, and \code{"native"} loads the LPC's R module instead, leaving the package library to \code{renv}. Use \code{"native"} when the project library was built against a module-provided R: a worker that loads a library built for a different R version fails with errors such as \code{unused arguments (controller = ...)}, because the worker and the controller then run different \code{crew} versions.
 }
 \examples{
 \dontrun{
 use_crew_lsf()
+use_crew_lsf(runtime = "native")
 }
 }
 \concept{targets}

--- a/man/use_crew_lsf.Rd
+++ b/man/use_crew_lsf.Rd
@@ -4,10 +4,10 @@
 \alias{use_crew_lsf}
 \title{Use crew lsf to execute a targets pipeline using the LSF HPC scheduler}
 \usage{
-use_crew_lsf(runtime = c("container", "native"))
+use_crew_lsf(runtime = c("native", "container"))
 }
 \arguments{
-\item{runtime}{(character) R runtime the LSF workers use: \code{"container"} for the LPC RStudio Singularity image, or \code{"native"} for the module-provided R}
+\item{runtime}{(character) R runtime the LSF workers use: \code{"native"} (the default) for the module-provided R, or \code{"container"} for the LPC RStudio Singularity image}
 }
 \value{
 A code block to copy/paste into a targets project
@@ -17,12 +17,12 @@ A code block to copy/paste into a targets project
 
 This function returns a template for using \code{crew.cluster} in a targets project, enabling the parallel execution of a targets workflow. By default, the template is pre-filled using parameters specific to the LPC system at Penn. By default, this function creates workers that submit to different queues (eg. \code{voltron_normal}, \code{voltron_long}), and allocate different resources (eg. a "normal" worker will use 1 core and 16GB memory, while a "long" worker will use 1 core and 10GB memory).
 
-The \code{runtime} argument selects the R installation the workers run against. \code{"container"} runs each worker inside the LPC's RStudio Singularity image, and \code{"native"} loads the LPC's R module instead, leaving the package library to \code{renv}. Use \code{"native"} when the project library was built against a module-provided R: a worker that loads a library built for a different R version fails with errors such as \code{unused arguments (controller = ...)}, because the worker and the controller then run different \code{crew} versions.
+The \code{runtime} argument selects the R installation the workers run against. \code{"native"}, the default, loads the LPC's R module and leaves the package library to \code{renv}; \code{"container"} runs each worker inside the LPC's RStudio Singularity image instead. Use \code{"container"} only when the project library was built against that image: a worker that loads a library built for a different R version fails with errors such as \code{unused arguments (controller = ...)}, because the worker and the controller then run different \code{crew} versions.
 }
 \examples{
 \dontrun{
 use_crew_lsf()
-use_crew_lsf(runtime = "native")
+use_crew_lsf(runtime = "container")
 }
 }
 \concept{targets}

--- a/tests/testthat/test-use_crew_lsf.R
+++ b/tests/testthat/test-use_crew_lsf.R
@@ -4,22 +4,22 @@ test_that("use_crew_lsf works", {
   expect_true(inherits(use_crew_lsf, "function"))
 })
 
-test_that("use_crew_lsf defaults to the container runtime", {
+test_that("use_crew_lsf defaults to the native runtime", {
   template <- suppressMessages(use_crew_lsf())
   expect_identical(
     as.character(template),
-    as.character(suppressMessages(use_crew_lsf(runtime = "container")))
+    as.character(suppressMessages(use_crew_lsf(runtime = "native")))
   )
-  expect_true(grepl("singularity exec", template, fixed = TRUE))
-  expect_true(grepl("export SINGULARITY_BIND=", template, fixed = TRUE))
-  expect_false(grepl("module load", template, fixed = TRUE))
-})
-
-test_that("use_crew_lsf loads an R module under the native runtime", {
-  template <- suppressMessages(use_crew_lsf(runtime = "native"))
   expect_true(grepl("module load R/", template, fixed = TRUE))
   expect_false(grepl("singularity exec", template, fixed = TRUE))
   expect_false(grepl("R_LIBS_USER", template, fixed = TRUE))
+})
+
+test_that("use_crew_lsf runs workers in the image under the container runtime", {
+  template <- suppressMessages(use_crew_lsf(runtime = "container"))
+  expect_true(grepl("singularity exec", template, fixed = TRUE))
+  expect_true(grepl("export SINGULARITY_BIND=", template, fixed = TRUE))
+  expect_false(grepl("module load", template, fixed = TRUE))
 })
 
 test_that("use_crew_lsf returns parseable R code for either runtime", {

--- a/tests/testthat/test-use_crew_lsf.R
+++ b/tests/testthat/test-use_crew_lsf.R
@@ -3,3 +3,32 @@
 test_that("use_crew_lsf works", {
   expect_true(inherits(use_crew_lsf, "function"))
 })
+
+test_that("use_crew_lsf defaults to the container runtime", {
+  template <- suppressMessages(use_crew_lsf())
+  expect_identical(
+    as.character(template),
+    as.character(suppressMessages(use_crew_lsf(runtime = "container")))
+  )
+  expect_true(grepl("singularity exec", template, fixed = TRUE))
+  expect_true(grepl("export SINGULARITY_BIND=", template, fixed = TRUE))
+  expect_false(grepl("module load", template, fixed = TRUE))
+})
+
+test_that("use_crew_lsf loads an R module under the native runtime", {
+  template <- suppressMessages(use_crew_lsf(runtime = "native"))
+  expect_true(grepl("module load R/", template, fixed = TRUE))
+  expect_false(grepl("singularity exec", template, fixed = TRUE))
+  expect_false(grepl("R_LIBS_USER", template, fixed = TRUE))
+})
+
+test_that("use_crew_lsf returns parseable R code for either runtime", {
+  for (runtime in c("container", "native")) {
+    template <- suppressMessages(use_crew_lsf(runtime = runtime))
+    expect_true(length(parse(text = template)) > 0)
+  }
+})
+
+test_that("use_crew_lsf rejects an unknown runtime", {
+  expect_error(use_crew_lsf(runtime = "singularity"), "must be one of")
+})

--- a/vignettes/create-a-new-targets-pipeline-for-lpc.Rmd
+++ b/vignettes/create-a-new-targets-pipeline-for-lpc.Rmd
@@ -58,7 +58,7 @@ The `targets` package is a tool for developing reproducible research workflows i
 
 The `populate_targets_proj` function can be run within a new project folder to initialize the project with the files/folders necessary for deploying a `targets` pipeline on the LPC at Penn. This includes creating LSF templates, a `Pipelines.qmd` file containing boilerplate for running analyses, and a `Results.qmd` file which can be used to visualize the results.
 
-The `runtime` argument chooses the R installation the pipeline runs against. `"container"` (the default) runs the main `targets` process and every LSF worker inside the LPC's RStudio Singularity image, reading packages from a library built against that image's R. `"native"` loads the LPC's R module (`module load R/4.5`) instead and leaves the package library to `renv`, which is the right choice for a project whose library was built against a module-provided R. Mixing the two fails at run time: a worker that loads a library built for a different R version reports errors such as `unused arguments (controller = ...)`, because the worker and the controller end up running different `crew` versions.
+The `runtime` argument chooses the R installation the pipeline runs against. `"native"` (the default) loads the LPC's R module (`module load R/4.5`) and leaves the package library to `renv`. `"container"` instead runs the main `targets` process and every LSF worker inside the LPC's RStudio Singularity image, reading packages from a library built against that image's R, which is the right choice only for a project whose library was built against that image. Mixing the two fails at run time: a worker that loads a library built for a different R version reports errors such as `unused arguments (controller = ...)`, because the worker and the controller end up running different `crew` versions.
 
 <!--
 Here is an example on how to use the function.
@@ -69,7 +69,7 @@ This should be a reproducible and working example
 
 #' \dontrun{
 populate_targets_proj("test")
-populate_targets_proj("test", runtime = "native")
+populate_targets_proj("test", runtime = "container")
 #' }
 ```
 
@@ -131,7 +131,7 @@ The `crew` and `crew.cluster` packages have enabled the use of heterogenous work
 
 #' \dontrun{
 use_crew_lsf()
-use_crew_lsf(runtime = "native")
+use_crew_lsf(runtime = "container")
 #' }
 ```
 

--- a/vignettes/create-a-new-targets-pipeline-for-lpc.Rmd
+++ b/vignettes/create-a-new-targets-pipeline-for-lpc.Rmd
@@ -58,6 +58,8 @@ The `targets` package is a tool for developing reproducible research workflows i
 
 The `populate_targets_proj` function can be run within a new project folder to initialize the project with the files/folders necessary for deploying a `targets` pipeline on the LPC at Penn. This includes creating LSF templates, a `Pipelines.qmd` file containing boilerplate for running analyses, and a `Results.qmd` file which can be used to visualize the results.
 
+The `runtime` argument chooses the R installation the pipeline runs against. `"container"` (the default) runs the main `targets` process and every LSF worker inside the LPC's RStudio Singularity image, reading packages from a library built against that image's R. `"native"` loads the LPC's R module (`module load R/4.5`) instead and leaves the package library to `renv`, which is the right choice for a project whose library was built against a module-provided R. Mixing the two fails at run time: a worker that loads a library built for a different R version reports errors such as `unused arguments (controller = ...)`, because the worker and the controller end up running different `crew` versions.
+
 <!--
 Here is an example on how to use the function.
 This should be a reproducible and working example
@@ -67,11 +69,12 @@ This should be a reproducible and working example
 
 #' \dontrun{
 populate_targets_proj("test")
+populate_targets_proj("test", runtime = "native")
 #' }
 ```
 
 
-The `populate_targets_proj()` function creates several files/folders within the project directory. `.make-targets.sh` and is a hidden helper file which is not designed for user interaction, but necessary for submission of jobs to the LSF scheduler. The other files are designed to be edited/used by the user:
+The `populate_targets_proj()` function creates several files/folders within the project directory. `.make-targets.sh` and is a hidden helper file which is not designed for user interaction, but necessary for submission of jobs to the LSF scheduler; its contents follow the `runtime` argument, so that the main `targets` process runs under the same R as the workers. The other files are designed to be edited/used by the user:
 
   - `Pipeline.qmd` - Quarto markdown file which can be used to create a Target Markdown document that specifies a `targets` pipeline for your analyses. See: https://books.ropensci.org/targets/literate-programming.html#target-markdown for details. Remember to knit/render this document in order to generate the pipeline.
   
@@ -118,6 +121,8 @@ Here are some unit tests to verify the function works as expected.
 ### Use {crew} for parallelization
 
 The `crew` and `crew.cluster` packages have enabled the use of heterogenous workers (<https://books.ropensci.org/targets/crew.html#heterogeneous-workers>), that can be used to deploy `targets` pipelines either locally or on HPC resources. The `use_crew_lsf()` function is designed to return a block of code to rapidly enable the use of heterogeneous workers on the Penn LPC. By default, this function creates workers that submit to different queues (eg. `voltron_normal`, `voltron_long`), and allocate different resources (eg. a "normal" worker will use 1 core and 16GB memory, while a "long" worker will use 1 core and 10GB memory).
+
+`use_crew_lsf()` takes the same `runtime` argument as `populate_targets_proj()`, which controls the shell lines that open each worker script. Under `"container"` the worker exports `R_LIBS_USER` and `SINGULARITY_BIND` and then runs R through `singularity exec`; under `"native"` it runs `module load R/4.5` and nothing else, so the project library comes from `renv/activate.R` (`crew_options_lsf()` defaults `cwd` to the project directory). The two branches also differ in the `crew.cluster` interface they emit: the container branch keeps the older `lsf_*` arguments to `crew_controller_lsf()`, which is what the `crew.cluster` build inside the image understands, while the native branch uses the `crew_options_lsf()` interface that replaced them.
     
 
   
@@ -126,6 +131,7 @@ The `crew` and `crew.cluster` packages have enabled the use of heterogenous work
 
 #' \dontrun{
 use_crew_lsf()
+use_crew_lsf(runtime = "native")
 #' }
 ```
 


### PR DESCRIPTION
## Summary

`populate_targets_proj()` and `use_crew_lsf()` take a new `runtime = c("native", "container")` argument that selects the R installation the pipeline and its LSF workers run against. `populate_targets_proj()` passes its value through to `use_crew_lsf()`.

**`"native"` (the default)** emits `module load R/4.5` as the only runtime line in each worker script: no `R_LIBS_USER`, no `singularity exec`, so the worker takes its library from `renv/activate.R` because `crew_options_lsf()` defaults `cwd` to the project directory. These controllers use the current `crew_options_lsf()` interface (`script_directory`, `log_output`, `log_error`, `memory_gigabytes_limit`, `cores`).

**`"container"`** reproduces the previous template byte for byte, verified by diffing the generated output against `main`. Each worker exports `R_LIBS_USER` and `SINGULARITY_BIND` and runs R through `singularity exec` against the LPC RStudio image, and the controllers keep the older `lsf_*` arguments that the `crew.cluster` build inside the image understands.

`populate_targets_proj()` also writes `.make-targets.sh` from a runtime-matched template, so the main `targets` process runs under the same R as its workers. The new `inst/templates/.make-targets-native.sh` drops Singularity and runs `module load R/4.5` before `targets::tar_make()`.

Mixing the two runtimes is what this argument exists to prevent: a worker that loads a library built for a different R version fails with errors such as `unused arguments (controller = ...)`, because the worker and the controller then run different `crew` versions.

## Changes

- `dev/LPC_targets_project.Rmd` — the {fusen} source of truth for both functions, their documentation, the prose, and the tests
- `R/populate_targets_proj.R`, `R/use_crew_lsf.R`, `man/*.Rd`, `tests/testthat/test-use_crew_lsf.R`, `vignettes/create-a-new-targets-pipeline-for-lpc.Rmd` — generated files, hand-matched to the flat file
- `inst/templates/.make-targets-native.sh` — new

## Testing

Ran the generated templates under R: both runtimes emit parseable R (11 top-level expressions each), the container variant's `singularity exec` line still ends in a single backslash continuation, and the container output is identical to what `main` produces. A stubbed `populate_targets_proj()` run selects the right `.make-targets` template for each runtime. `bash -n` passes on the new shell template.

Four tests added to `test-use_crew_lsf.R` cover the default, each runtime's script lines, parseability of both templates, and rejection of an unknown value. All pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017B527xBJkojash9bnju7L8

---
_Generated by [Claude Code](https://claude.ai/code/session_017B527xBJkojash9bnju7L8)_