### PR TITLE
Write Pipeline.qmd targets chunks in the r, engine = "targets" form

### DIFF
--- a/inst/templates/Pipeline.qmd
+++ b/inst/templates/Pipeline.qmd
@@ -39,11 +39,11 @@ tar_unscript()
 
 # Targets Pipeline
 
-```{targets globals, tar_globals = TRUE}
+```{r globals, engine = "targets", tar_globals = TRUE}
 {{{global_options}}}
 ```
 
-```{targets arrow-storage}
+```{r arrow-storage, engine = "targets"}
 format_arrow_table <- function() {
   targets::tar_format(
     read = function(path) {
@@ -74,7 +74,7 @@ format_arrow_dataset <- function() {
 
 # Analysis
 
-```{targets study-overview}
+```{r study-overview, engine = "targets"}
 
 ```
 


### PR DESCRIPTION
## Summary

The Target Markdown chunks in the generated `Pipeline.qmd` opened with ` ```{targets label} `, which R tooling does not recognise as R code, so air and panache skip them when linting and formatting a pipeline. All three chunks now open with the `r` language token and set the engine as a chunk option instead, keeping their labels:

```
```{r globals, engine = "targets", tar_globals = TRUE}
```{r arrow-storage, engine = "targets"}
```{r study-overview, engine = "targets"}
```

knitr treats the two forms as the same chunk: the `engine` option overrides the language token, and the targets engine receives the same `label`, `tar_globals` value and `code`.

## Changes

- `inst/templates/Pipeline.qmd` — the three Target Markdown chunk headers. This is a plain package template, not a {fusen}-generated file, so nothing under `dev/` changed.

## Testing

Registered a stub engine under knitr and compared the options it was handed for both chunk forms: `label`, `engine`, `tar_globals` and `code` come through identically. Then knit a fully populated copy of the template, with the whisker placeholder filled from real `use_crew_lsf()` output, and confirmed all three chunks route to the targets engine with the right labels and options, and that each body parses as R — which is what `targets::tar_engine_knitr()` does with them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017B527xBJkojash9bnju7L8

---
_Generated by [Claude Code](https://claude.ai/code/session_017B527xBJkojash9bnju7L8)_