### PR TITLE
Drop the deprecated qs package from the pipeline templates

### DIFF
--- a/R/use_crew_lsf.R
+++ b/R/use_crew_lsf.R
@@ -128,7 +128,7 @@ controller_local <- crew_controller_local(
 options(tidyverse.quiet = TRUE)
 
 tar_option_set(
-  packages = c('tidyverse', 'targets', 'tarchetypes', 'arrow', 'vroom', 'data.table', 'qs', 'gt', 'crew', 'crew.cluster'),
+  packages = c('tidyverse', 'targets', 'tarchetypes', 'arrow', 'vroom', 'data.table', 'gt', 'crew', 'crew.cluster'),
   controller = crew::crew_controller_group(controller_lsf_long, controller_lsf_normal, controller_lsf_highmem, controller_lsf_multicore, controller_local),
   resources = tar_resources(
     crew = tar_resources_crew(controller = '{title}_normal')

--- a/dev/LPC_targets_project.Rmd
+++ b/dev/LPC_targets_project.Rmd
@@ -373,7 +373,7 @@ controller_local <- crew_controller_local(
 options(tidyverse.quiet = TRUE)
 
 tar_option_set(
-  packages = c('tidyverse', 'targets', 'tarchetypes', 'arrow', 'vroom', 'data.table', 'qs', 'gt', 'crew', 'crew.cluster'),
+  packages = c('tidyverse', 'targets', 'tarchetypes', 'arrow', 'vroom', 'data.table', 'gt', 'crew', 'crew.cluster'),
   controller = crew::crew_controller_group(controller_lsf_long, controller_lsf_normal, controller_lsf_highmem, controller_lsf_multicore, controller_local),
   resources = tar_resources(
     crew = tar_resources_crew(controller = '{title}_normal')

--- a/inst/templates/Pipeline.qmd
+++ b/inst/templates/Pipeline.qmd
@@ -29,7 +29,6 @@ library(targets)
 library(data.table)
 library(vroom)
 library(arrow)
-library(qs)
 library(tarchetypes)
 
 theme_set(theme_bw(base_size = 16))


### PR DESCRIPTION
## Summary

`qs` is deprecated in favour of `qs2`, and nothing in the generated project actually used it. It appeared in two places that both land in the generated `Pipeline.qmd`:

- `inst/templates/Pipeline.qmd` attached it with `library(qs)` in the setup chunk.
- `use_crew_lsf()` named it in `tar_option_set(packages = ...)`, which is written into the globals chunk.

No target in either template declares `format = "qs"`, so removing both references changes nothing at run time — targets keeps using its default RDS storage. A project that wants the format can add `qs2` to its own package list.

`Results.qmd` never referenced `qs`.

## Changes

- `inst/templates/Pipeline.qmd` — removed `library(qs)`
- `dev/LPC_targets_project.Rmd` — the {fusen} source of truth: dropped `'qs'` from the `packages` vector in `use_crew_lsf()`
- `R/use_crew_lsf.R` — the generated counterpart

## Testing

Re-knit a populated copy of `Pipeline.qmd` with a stub targets engine: all three Target Markdown chunks still route correctly and their bodies parse as R. `use_crew_lsf()` output parses for both runtimes (11 top-level expressions each) and no longer mentions `qs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017B527xBJkojash9bnju7L8

---
_Generated by [Claude Code](https://claude.ai/code/session_017B527xBJkojash9bnju7L8)_